### PR TITLE
Fix: Thread Safety Crashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ testpaths = ["tests"]
 
 [tool.mypy]
 ignore_missing_imports = true
+exclude = ["liblsl"]
 
 [tool.ruff]
 line-length = 88

--- a/src/mobi_marker/lsl_stream.py
+++ b/src/mobi_marker/lsl_stream.py
@@ -1,0 +1,100 @@
+"""LSL stream management module.
+
+Provides thread-safe LSL stream handling for sending markers.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pylsl import StreamInfo, StreamOutlet, local_clock
+from PyQt6.QtCore import QMutex, QMutexLocker, QThread, pyqtSignal, pyqtSlot
+
+
+def format_timestamp() -> tuple[str, float]:
+    """Get formatted human time and LSL clock time."""
+    human_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    lsl_time = local_clock()
+    return human_time, lsl_time
+
+
+def format_status_message(message: str) -> str:
+    """Format a status message with timestamps."""
+    human_time, lsl_time = format_timestamp()
+    return f"[{human_time} | LSL: {lsl_time:.3f}] {message}"
+
+
+class LSLStreamThread(QThread):
+    """Thread for managing the LSL stream outlet.
+
+    Handles creation and management of an LSL stream in a separate thread
+    to keep the GUI responsive.
+    """
+
+    status_update = pyqtSignal(str)
+    stream_ready = pyqtSignal(bool)
+    marker_request = pyqtSignal(str)
+
+    def __init__(self) -> None:
+        """Initialize the LSL stream thread."""
+        super().__init__()
+        self.outlet: Optional[StreamOutlet] = None
+        self.stream_info: Optional[StreamInfo] = None
+        self._mutex = QMutex()
+        self._is_ready = False
+
+    def run(self) -> None:
+        """Create and maintain the LSL stream."""
+        try:
+            stream_info = StreamInfo(
+                name="MobiMarkerStream",
+                type="Markers",
+                channel_count=1,
+                nominal_srate=0,
+                channel_format="string",
+                source_id="mobi_marker_gui_v1",
+            )
+            outlet = StreamOutlet(stream_info)
+
+            with QMutexLocker(self._mutex):
+                self.stream_info = stream_info
+                self.outlet = outlet
+                self._is_ready = True
+
+            self.status_update.emit(
+                format_status_message("LSL stream started successfully")
+            )
+            self.stream_ready.emit(True)
+
+            self.marker_request.connect(self._handle_marker_request)
+            self.exec()
+
+        except Exception as e:
+            self.status_update.emit(
+                format_status_message(f"Error starting LSL stream: {e}")
+            )
+            self.stream_ready.emit(False)
+
+    def send_marker(self, marker: str) -> None:
+        """Request to send a marker (thread-safe, callable from GUI thread)."""
+        with QMutexLocker(self._mutex):
+            if not self._is_ready:
+                self.status_update.emit(format_status_message("LSL stream not active"))
+                return
+
+        self.marker_request.emit(marker)
+
+    @pyqtSlot(str)
+    def _handle_marker_request(self, marker: str) -> None:
+        """Handle marker request in the worker thread."""
+        with QMutexLocker(self._mutex):
+            outlet = self.outlet
+
+        if outlet is None:
+            self.status_update.emit(format_status_message("LSL stream not active"))
+            return
+
+        try:
+            outlet.push_sample([marker])
+            self.status_update.emit(format_status_message(f"Sent marker: {marker}"))
+        except Exception as e:
+            self.status_update.emit(format_status_message(f"Error sending marker: {e}"))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,50 +1,16 @@
-"""Test suite for GUI components.
-
-This module contains tests for the GUI components of the MoBI Marker
-application, including the LSL stream thread and main window.
-
-Functions:
-    test_lsl_stream_thread_initialization: Tests LSL stream thread initialization.
-    test_gui_window_initialization: Tests GUI window initialization.
-    test_send_quick_marker: Tests quick marker sending through LSL stream.
-"""
+"""Tests for the GUI module."""
 
 from unittest.mock import Mock, patch
 
-from mobi_marker.gui import LSLStreamThread, MobiMarkerGUI
+import pytest
+
+from mobi_marker.gui import AVAILABLE_MODALITIES, MobiMarkerGUI, main
+from mobi_marker.lsl_stream import LSLStreamThread
 
 
-def test_lsl_stream_thread_initialization() -> None:
-    """Test that LSLStreamThread can be initialized.
-
-    Verifies that the LSL stream thread can be created with proper
-    initial state (no outlet or stream_info).
-
-    Returns:
-        None
-
-    Raises:
-        AssertionError: If the thread is not initialized correctly.
-    """
-    with patch("mobi_marker.gui.StreamInfo"), patch("mobi_marker.gui.StreamOutlet"):
-        thread = LSLStreamThread()
-
-        assert thread.outlet is None
-        assert thread.stream_info is None
-
-
-def test_gui_window_initialization() -> None:
-    """Test that the GUI window can be initialized without showing.
-
-    Verifies that the main GUI window can be created without displaying
-    it, using mocked dependencies to avoid Qt application requirements.
-
-    Returns:
-        None
-
-    Raises:
-        AssertionError: If the GUI window is not initialized correctly.
-    """
+@pytest.fixture
+def mock_gui() -> MobiMarkerGUI:
+    """Create a mocked GUI instance."""
     with (
         patch("mobi_marker.gui.QApplication"),
         patch("mobi_marker.gui.QMainWindow.__init__"),
@@ -52,101 +18,354 @@ def test_gui_window_initialization() -> None:
         patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
     ):
         gui = MobiMarkerGUI()
-
-        assert gui is not None
-
-
-def test_send_quick_marker() -> None:
-    """Test that quick markers can be sent through the LSL stream.
-
-    Verifies that the send_quick_marker method correctly sends predefined
-    markers through the LSL stream thread.
-
-    Returns:
-        None
-
-    Raises:
-        AssertionError: If the quick marker functionality doesn't work correctly.
-    """
-    with (
-        patch("mobi_marker.gui.QApplication"),
-        patch("mobi_marker.gui.QMainWindow.__init__"),
-        patch("mobi_marker.gui.MobiMarkerGUI.init_ui"),
-        patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
-    ):
-        gui = MobiMarkerGUI()
-        mock_thread = Mock(spec=LSLStreamThread)
-        gui.lsl_thread = mock_thread
-
-        gui.send_quick_marker("START")
-
-        mock_thread.send_marker.assert_called_once_with("START")
+        gui.lsl_thread = Mock(spec=LSLStreamThread)
+        gui.marker_input = Mock()
+        gui.status_display = Mock()
+        gui.modality_combo = Mock()
+        gui.custom_modality_input = Mock()
+        gui.send_button = Mock()
+        gui.end_modality_button = Mock()
+        gui.quick_marker_buttons = [Mock(), Mock(), Mock()]
+        return gui
 
 
-def test_send_end_modality_marker() -> None:
-    """Test that end modality markers can be sent with dropdown selection.
+class TestAvailableModalities:
+    """Tests for AVAILABLE_MODALITIES constant."""
 
-    Verifies that the send_end_modality_marker method correctly constructs
-    and sends END [modality] markers based on dropdown selection.
+    def test_contains_eeg(self) -> None:
+        """EEG is in the modalities list."""
+        assert "EEG" in AVAILABLE_MODALITIES
 
-    Returns:
-        None
-
-    Raises:
-        AssertionError: If the end modality marker functionality doesn't work correctly.
-    """
-    with (
-        patch("mobi_marker.gui.QApplication"),
-        patch("mobi_marker.gui.QMainWindow.__init__"),
-        patch("mobi_marker.gui.MobiMarkerGUI.init_ui"),
-        patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
-    ):
-        gui = MobiMarkerGUI()
-        mock_thread = Mock(spec=LSLStreamThread)
-        gui.lsl_thread = mock_thread
-
-        mock_combo = Mock()
-        mock_combo.currentText.return_value = "EEG"
-        gui.modality_combo = mock_combo
-
-        mock_input = Mock()
-        gui.custom_modality_input = mock_input
-
-        gui.send_end_modality_marker()
-
-        mock_thread.send_marker.assert_called_once_with("END EEG")
+    def test_other_is_last(self) -> None:
+        """Other is the last item for custom input."""
+        assert AVAILABLE_MODALITIES[-1] == "Other"
 
 
-def test_send_end_modality_marker_custom() -> None:
-    """Test that custom end modality markers work with 'Other' selection.
+class TestMobiMarkerGUIInit:
+    """Tests for MobiMarkerGUI initialization."""
 
-    Verifies that when "Other" is selected, the custom input field is used
-    to construct the END [modality] marker.
+    def test_lsl_thread_starts_none(self) -> None:
+        """LSL thread is None before start_lsl_stream runs."""
+        with (
+            patch("mobi_marker.gui.QApplication"),
+            patch("mobi_marker.gui.QMainWindow.__init__"),
+            patch("mobi_marker.gui.MobiMarkerGUI.init_ui"),
+            patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
+        ):
+            gui = MobiMarkerGUI()
 
-    Returns:
-        None
+        assert gui.lsl_thread is None
 
-    Raises:
-        AssertionError: If the custom modality functionality doesn't work correctly.
-    """
-    with (
-        patch("mobi_marker.gui.QApplication"),
-        patch("mobi_marker.gui.QMainWindow.__init__"),
-        patch("mobi_marker.gui.MobiMarkerGUI.init_ui"),
-        patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
-    ):
-        gui = MobiMarkerGUI()
-        mock_thread = Mock(spec=LSLStreamThread)
-        gui.lsl_thread = mock_thread
 
-        mock_combo = Mock()
-        mock_combo.currentText.return_value = "Other"
-        gui.modality_combo = mock_combo
+class TestSendMarker:
+    """Tests for MobiMarkerGUI.send_marker() method."""
 
-        mock_input = Mock()
-        mock_input.text.return_value.strip.return_value = "Custom Sensor"
-        gui.custom_modality_input = mock_input
+    def test_valid_input_sends_to_thread(self, mock_gui: MobiMarkerGUI) -> None:
+        """Valid marker text is sent to the LSL thread."""
+        mock_gui.marker_input.text.return_value.strip.return_value = "Test Marker"
 
-        gui.send_end_modality_marker()
+        mock_gui.send_marker()
 
-        mock_thread.send_marker.assert_called_once_with("END CUSTOM SENSOR")
+        mock_gui.lsl_thread.send_marker.assert_called_once_with("Test Marker")
+
+    def test_valid_input_clears_field(self, mock_gui: MobiMarkerGUI) -> None:
+        """Input field is cleared after sending."""
+        mock_gui.marker_input.text.return_value.strip.return_value = "Test"
+
+        mock_gui.send_marker()
+
+        mock_gui.marker_input.clear.assert_called_once()
+
+    def test_empty_input_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
+        """Empty input shows error in status."""
+        mock_gui.marker_input.text.return_value.strip.return_value = ""
+
+        with patch("mobi_marker.gui.format_status_message", return_value="error msg"):
+            mock_gui.send_marker()
+
+        mock_gui.lsl_thread.send_marker.assert_not_called()
+        mock_gui.status_display.append.assert_called()
+
+    def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
+        """No LSL thread shows error in status."""
+        mock_gui.lsl_thread = None
+        mock_gui.marker_input.text.return_value.strip.return_value = "Test"
+
+        with patch("mobi_marker.gui.format_status_message", return_value="error msg"):
+            mock_gui.send_marker()
+
+        mock_gui.status_display.append.assert_called()
+
+
+class TestSendQuickMarker:
+    """Tests for MobiMarkerGUI.send_quick_marker() method."""
+
+    def test_sends_to_thread(self, mock_gui: MobiMarkerGUI) -> None:
+        """Quick marker is sent to the LSL thread."""
+        mock_gui.send_quick_marker("START")
+
+        mock_gui.lsl_thread.send_marker.assert_called_once_with("START")
+
+    def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
+        """No LSL thread shows error in status."""
+        mock_gui.lsl_thread = None
+
+        with patch("mobi_marker.gui.format_status_message", return_value="error"):
+            mock_gui.send_quick_marker("START")
+
+        mock_gui.status_display.append.assert_called()
+
+
+class TestSendEndModalityMarker:
+    """Tests for MobiMarkerGUI.send_end_modality_marker() method."""
+
+    def test_standard_modality_sends_formatted(self, mock_gui: MobiMarkerGUI) -> None:
+        """Standard modality sends 'END <modality>'."""
+        mock_gui.modality_combo.currentText.return_value = "EEG"
+
+        mock_gui.send_end_modality_marker()
+
+        mock_gui.lsl_thread.send_marker.assert_called_once_with("END EEG")
+
+    def test_custom_modality_sends_uppercase(self, mock_gui: MobiMarkerGUI) -> None:
+        """Custom modality is uppercased."""
+        mock_gui.modality_combo.currentText.return_value = "Other"
+        mock_gui.custom_modality_input.text.return_value.strip.return_value = "custom"
+
+        mock_gui.send_end_modality_marker()
+
+        mock_gui.lsl_thread.send_marker.assert_called_once_with("END CUSTOM")
+
+    def test_custom_modality_clears_input(self, mock_gui: MobiMarkerGUI) -> None:
+        """Custom input field is cleared after sending."""
+        mock_gui.modality_combo.currentText.return_value = "Other"
+        mock_gui.custom_modality_input.text.return_value.strip.return_value = "sensor"
+
+        mock_gui.send_end_modality_marker()
+
+        mock_gui.custom_modality_input.clear.assert_called_once()
+
+    def test_empty_custom_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
+        """Empty custom modality shows error."""
+        mock_gui.modality_combo.currentText.return_value = "Other"
+        mock_gui.custom_modality_input.text.return_value.strip.return_value = ""
+
+        with patch("mobi_marker.gui.format_status_message", return_value="error"):
+            mock_gui.send_end_modality_marker()
+
+        mock_gui.lsl_thread.send_marker.assert_not_called()
+
+    def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
+        """No LSL thread shows error in status."""
+        mock_gui.lsl_thread = None
+        mock_gui.modality_combo.currentText.return_value = "EEG"
+
+        with patch("mobi_marker.gui.format_status_message", return_value="error"):
+            mock_gui.send_end_modality_marker()
+
+        mock_gui.status_display.append.assert_called()
+
+
+class TestOnModalityChanged:
+    """Tests for MobiMarkerGUI.on_modality_changed() method."""
+
+    def test_other_shows_custom_input(self, mock_gui: MobiMarkerGUI) -> None:
+        """Selecting 'Other' shows custom input field."""
+        mock_gui.on_modality_changed("Other")
+
+        mock_gui.custom_modality_input.setVisible.assert_called_once_with(True)
+
+    def test_other_focuses_custom_input(self, mock_gui: MobiMarkerGUI) -> None:
+        """Selecting 'Other' focuses custom input field."""
+        mock_gui.on_modality_changed("Other")
+
+        mock_gui.custom_modality_input.setFocus.assert_called_once()
+
+    def test_standard_modality_hides_input(self, mock_gui: MobiMarkerGUI) -> None:
+        """Selecting standard modality hides custom input."""
+        mock_gui.on_modality_changed("EEG")
+
+        mock_gui.custom_modality_input.setVisible.assert_called_once_with(False)
+
+
+class TestOnStreamReady:
+    """Tests for MobiMarkerGUI.on_stream_ready() method."""
+
+    def test_ready_enables_send_button(self, mock_gui: MobiMarkerGUI) -> None:
+        """Stream ready enables send button."""
+        mock_gui.on_stream_ready(True)
+
+        mock_gui.send_button.setEnabled.assert_called_once_with(True)
+
+    def test_ready_enables_modality_button(self, mock_gui: MobiMarkerGUI) -> None:
+        """Stream ready enables end modality button."""
+        mock_gui.on_stream_ready(True)
+
+        mock_gui.end_modality_button.setEnabled.assert_called_once_with(True)
+
+    def test_ready_enables_quick_buttons(self, mock_gui: MobiMarkerGUI) -> None:
+        """Stream ready enables all quick marker buttons."""
+        mock_gui.on_stream_ready(True)
+
+        for button in mock_gui.quick_marker_buttons:
+            button.setEnabled.assert_called_once_with(True)
+
+    def test_not_ready_disables_buttons(self, mock_gui: MobiMarkerGUI) -> None:
+        """Stream not ready disables buttons."""
+        with patch("mobi_marker.gui.format_status_message", return_value="warning"):
+            mock_gui.on_stream_ready(False)
+
+        mock_gui.send_button.setEnabled.assert_called_once_with(False)
+
+    def test_not_ready_shows_warning(self, mock_gui: MobiMarkerGUI) -> None:
+        """Stream not ready shows warning in status."""
+        with patch("mobi_marker.gui.format_status_message", return_value="warning"):
+            mock_gui.on_stream_ready(False)
+
+        mock_gui.status_display.append.assert_called()
+
+
+class TestUpdateStatus:
+    """Tests for MobiMarkerGUI.update_status() method."""
+
+    def test_appends_message(self, mock_gui: MobiMarkerGUI) -> None:
+        """Message is appended to status display."""
+        mock_gui.update_status("Test message")
+
+        mock_gui.status_display.append.assert_called_once_with("Test message")
+
+    def test_scrolls_to_bottom(self, mock_gui: MobiMarkerGUI) -> None:
+        """Status display scrolls to bottom."""
+        mock_scrollbar = Mock()
+        mock_scrollbar.maximum.return_value = 100
+        mock_gui.status_display.verticalScrollBar.return_value = mock_scrollbar
+
+        mock_gui.update_status("Test")
+
+        mock_scrollbar.setValue.assert_called_once_with(100)
+
+    def test_handles_none_scrollbar(self, mock_gui: MobiMarkerGUI) -> None:
+        """Handles None scrollbar gracefully."""
+        mock_gui.status_display.verticalScrollBar.return_value = None
+
+        mock_gui.update_status("Test")  # Should not raise
+
+
+class TestCloseEvent:
+    """Tests for MobiMarkerGUI.closeEvent() method."""
+
+    def test_quits_thread(self, mock_gui: MobiMarkerGUI) -> None:
+        """Thread is quit on close."""
+        mock_gui.lsl_thread.wait.return_value = True
+        mock_event = Mock()
+
+        mock_gui.closeEvent(mock_event)
+
+        mock_gui.lsl_thread.quit.assert_called_once()
+
+    def test_waits_for_thread(self, mock_gui: MobiMarkerGUI) -> None:
+        """Waits for thread with timeout."""
+        mock_gui.lsl_thread.wait.return_value = True
+        mock_event = Mock()
+
+        mock_gui.closeEvent(mock_event)
+
+        mock_gui.lsl_thread.wait.assert_called_once_with(3000)
+
+    def test_accepts_event(self, mock_gui: MobiMarkerGUI) -> None:
+        """Event is accepted."""
+        mock_gui.lsl_thread.wait.return_value = True
+        mock_event = Mock()
+
+        mock_gui.closeEvent(mock_event)
+
+        mock_event.accept.assert_called_once()
+
+    def test_timeout_terminates_thread(self, mock_gui: MobiMarkerGUI) -> None:
+        """Thread is terminated on timeout."""
+        mock_gui.lsl_thread.wait.side_effect = [False, True]
+        mock_event = Mock()
+
+        with patch("mobi_marker.gui.format_status_message", return_value="warning"):
+            mock_gui.closeEvent(mock_event)
+
+        mock_gui.lsl_thread.terminate.assert_called_once()
+
+    def test_no_thread_still_accepts(self, mock_gui: MobiMarkerGUI) -> None:
+        """Event is accepted even with no thread."""
+        mock_gui.lsl_thread = None
+        mock_event = Mock()
+
+        mock_gui.closeEvent(mock_event)
+
+        mock_event.accept.assert_called_once()
+
+    def test_none_event_handled(self, mock_gui: MobiMarkerGUI) -> None:
+        """None event is handled gracefully."""
+        mock_gui.lsl_thread.wait.return_value = True
+
+        mock_gui.closeEvent(None)  # Should not raise
+
+
+class TestStartLslStream:
+    """Tests for MobiMarkerGUI.start_lsl_stream() method."""
+
+    def test_creates_and_starts_thread(self) -> None:
+        """Creates and starts LSLStreamThread instance."""
+        with (
+            patch("mobi_marker.gui.QApplication"),
+            patch("mobi_marker.gui.QMainWindow.__init__"),
+            patch("mobi_marker.gui.MobiMarkerGUI.init_ui"),
+        ):
+            with patch("mobi_marker.gui.LSLStreamThread") as mock_thread_class:
+                mock_thread = Mock()
+                mock_thread_class.return_value = mock_thread
+
+                _ = MobiMarkerGUI()
+
+        mock_thread_class.assert_called_once()
+        mock_thread.start.assert_called_once()
+
+
+class TestMain:
+    """Tests for main() function."""
+
+    def test_creates_application(self) -> None:
+        """Creates QApplication."""
+        mock_app = Mock()
+        mock_app.exec.return_value = 0
+        with (
+            patch("mobi_marker.gui.QApplication", return_value=mock_app),
+            patch("mobi_marker.gui.MobiMarkerGUI"),
+            patch("mobi_marker.gui.sys.exit"),
+        ):
+            main()
+
+        mock_app.setApplicationName.assert_called_once_with("MoBI Marker")
+
+    def test_shows_window(self) -> None:
+        """Shows the main window."""
+        mock_app = Mock()
+        mock_app.exec.return_value = 0
+        with (
+            patch("mobi_marker.gui.QApplication", return_value=mock_app),
+            patch("mobi_marker.gui.MobiMarkerGUI") as mock_gui_class,
+            patch("mobi_marker.gui.sys.exit"),
+        ):
+            mock_window = Mock()
+            mock_gui_class.return_value = mock_window
+
+            main()
+
+        mock_window.show.assert_called_once()
+
+    def test_exception_exits_with_error(self) -> None:
+        """Exception causes exit with code 1."""
+        with (
+            patch("mobi_marker.gui.QApplication", side_effect=Exception("fail")),
+            patch("mobi_marker.gui.sys.exit") as mock_exit,
+            patch("builtins.print"),
+        ):
+            main()
+
+        mock_exit.assert_called_once_with(1)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,11 +1,11 @@
 """Tests for the GUI module."""
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
 
 from mobi_marker.gui import AVAILABLE_MODALITIES, MobiMarkerGUI, main
-from mobi_marker.lsl_stream import LSLStreamThread
 
 
 @pytest.fixture
@@ -18,7 +18,7 @@ def mock_gui() -> MobiMarkerGUI:
         patch("mobi_marker.gui.MobiMarkerGUI.start_lsl_stream"),
     ):
         gui = MobiMarkerGUI()
-        gui.lsl_thread = Mock(spec=LSLStreamThread)
+        gui.lsl_thread = Mock()
         gui.marker_input = Mock()
         gui.status_display = Mock()
         gui.modality_combo = Mock()
@@ -27,6 +27,46 @@ def mock_gui() -> MobiMarkerGUI:
         gui.end_modality_button = Mock()
         gui.quick_marker_buttons = [Mock(), Mock(), Mock()]
         return gui
+
+
+def _lsl_thread(gui: MobiMarkerGUI) -> Any:
+    """Return lsl_thread as Any for mock assertions."""
+    return gui.lsl_thread
+
+
+def _marker_input(gui: MobiMarkerGUI) -> Any:
+    """Return marker_input as Any for mock assertions."""
+    return gui.marker_input
+
+
+def _status_display(gui: MobiMarkerGUI) -> Any:
+    """Return status_display as Any for mock assertions."""
+    return gui.status_display
+
+
+def _modality_combo(gui: MobiMarkerGUI) -> Any:
+    """Return modality_combo as Any for mock assertions."""
+    return gui.modality_combo
+
+
+def _custom_modality_input(gui: MobiMarkerGUI) -> Any:
+    """Return custom_modality_input as Any for mock assertions."""
+    return gui.custom_modality_input
+
+
+def _send_button(gui: MobiMarkerGUI) -> Any:
+    """Return send_button as Any for mock assertions."""
+    return gui.send_button
+
+
+def _end_modality_button(gui: MobiMarkerGUI) -> Any:
+    """Return end_modality_button as Any for mock assertions."""
+    return gui.end_modality_button
+
+
+def _quick_marker_buttons(gui: MobiMarkerGUI) -> list[Any]:
+    """Return quick_marker_buttons as list[Any] for mock assertions."""
+    return gui.quick_marker_buttons  # type: ignore[return-value]
 
 
 class TestAvailableModalities:
@@ -62,39 +102,39 @@ class TestSendMarker:
 
     def test_valid_input_sends_to_thread(self, mock_gui: MobiMarkerGUI) -> None:
         """Valid marker text is sent to the LSL thread."""
-        mock_gui.marker_input.text.return_value.strip.return_value = "Test Marker"
+        _marker_input(mock_gui).text.return_value.strip.return_value = "Test Marker"
 
         mock_gui.send_marker()
 
-        mock_gui.lsl_thread.send_marker.assert_called_once_with("Test Marker")
+        _lsl_thread(mock_gui).send_marker.assert_called_once_with("Test Marker")
 
     def test_valid_input_clears_field(self, mock_gui: MobiMarkerGUI) -> None:
         """Input field is cleared after sending."""
-        mock_gui.marker_input.text.return_value.strip.return_value = "Test"
+        _marker_input(mock_gui).text.return_value.strip.return_value = "Test"
 
         mock_gui.send_marker()
 
-        mock_gui.marker_input.clear.assert_called_once()
+        _marker_input(mock_gui).clear.assert_called_once()
 
     def test_empty_input_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
         """Empty input shows error in status."""
-        mock_gui.marker_input.text.return_value.strip.return_value = ""
+        _marker_input(mock_gui).text.return_value.strip.return_value = ""
 
         with patch("mobi_marker.gui.format_status_message", return_value="error msg"):
             mock_gui.send_marker()
 
-        mock_gui.lsl_thread.send_marker.assert_not_called()
-        mock_gui.status_display.append.assert_called()
+        _lsl_thread(mock_gui).send_marker.assert_not_called()
+        _status_display(mock_gui).append.assert_called()
 
     def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
         """No LSL thread shows error in status."""
         mock_gui.lsl_thread = None
-        mock_gui.marker_input.text.return_value.strip.return_value = "Test"
+        _marker_input(mock_gui).text.return_value.strip.return_value = "Test"
 
         with patch("mobi_marker.gui.format_status_message", return_value="error msg"):
             mock_gui.send_marker()
 
-        mock_gui.status_display.append.assert_called()
+        _status_display(mock_gui).append.assert_called()
 
 
 class TestSendQuickMarker:
@@ -104,7 +144,7 @@ class TestSendQuickMarker:
         """Quick marker is sent to the LSL thread."""
         mock_gui.send_quick_marker("START")
 
-        mock_gui.lsl_thread.send_marker.assert_called_once_with("START")
+        _lsl_thread(mock_gui).send_marker.assert_called_once_with("START")
 
     def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
         """No LSL thread shows error in status."""
@@ -113,7 +153,7 @@ class TestSendQuickMarker:
         with patch("mobi_marker.gui.format_status_message", return_value="error"):
             mock_gui.send_quick_marker("START")
 
-        mock_gui.status_display.append.assert_called()
+        _status_display(mock_gui).append.assert_called()
 
 
 class TestSendEndModalityMarker:
@@ -121,49 +161,49 @@ class TestSendEndModalityMarker:
 
     def test_standard_modality_sends_formatted(self, mock_gui: MobiMarkerGUI) -> None:
         """Standard modality sends 'END <modality>'."""
-        mock_gui.modality_combo.currentText.return_value = "EEG"
+        _modality_combo(mock_gui).currentText.return_value = "EEG"
 
         mock_gui.send_end_modality_marker()
 
-        mock_gui.lsl_thread.send_marker.assert_called_once_with("END EEG")
+        _lsl_thread(mock_gui).send_marker.assert_called_once_with("END EEG")
 
     def test_custom_modality_sends_uppercase(self, mock_gui: MobiMarkerGUI) -> None:
         """Custom modality is uppercased."""
-        mock_gui.modality_combo.currentText.return_value = "Other"
-        mock_gui.custom_modality_input.text.return_value.strip.return_value = "custom"
+        _modality_combo(mock_gui).currentText.return_value = "Other"
+        _custom_modality_input(mock_gui).text.return_value.strip.return_value = "custom"
 
         mock_gui.send_end_modality_marker()
 
-        mock_gui.lsl_thread.send_marker.assert_called_once_with("END CUSTOM")
+        _lsl_thread(mock_gui).send_marker.assert_called_once_with("END CUSTOM")
 
     def test_custom_modality_clears_input(self, mock_gui: MobiMarkerGUI) -> None:
         """Custom input field is cleared after sending."""
-        mock_gui.modality_combo.currentText.return_value = "Other"
-        mock_gui.custom_modality_input.text.return_value.strip.return_value = "sensor"
+        _modality_combo(mock_gui).currentText.return_value = "Other"
+        _custom_modality_input(mock_gui).text.return_value.strip.return_value = "sensor"
 
         mock_gui.send_end_modality_marker()
 
-        mock_gui.custom_modality_input.clear.assert_called_once()
+        _custom_modality_input(mock_gui).clear.assert_called_once()
 
     def test_empty_custom_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
         """Empty custom modality shows error."""
-        mock_gui.modality_combo.currentText.return_value = "Other"
-        mock_gui.custom_modality_input.text.return_value.strip.return_value = ""
+        _modality_combo(mock_gui).currentText.return_value = "Other"
+        _custom_modality_input(mock_gui).text.return_value.strip.return_value = ""
 
         with patch("mobi_marker.gui.format_status_message", return_value="error"):
             mock_gui.send_end_modality_marker()
 
-        mock_gui.lsl_thread.send_marker.assert_not_called()
+        _lsl_thread(mock_gui).send_marker.assert_not_called()
 
     def test_no_thread_shows_error(self, mock_gui: MobiMarkerGUI) -> None:
         """No LSL thread shows error in status."""
         mock_gui.lsl_thread = None
-        mock_gui.modality_combo.currentText.return_value = "EEG"
+        _modality_combo(mock_gui).currentText.return_value = "EEG"
 
         with patch("mobi_marker.gui.format_status_message", return_value="error"):
             mock_gui.send_end_modality_marker()
 
-        mock_gui.status_display.append.assert_called()
+        _status_display(mock_gui).append.assert_called()
 
 
 class TestOnModalityChanged:
@@ -173,19 +213,19 @@ class TestOnModalityChanged:
         """Selecting 'Other' shows custom input field."""
         mock_gui.on_modality_changed("Other")
 
-        mock_gui.custom_modality_input.setVisible.assert_called_once_with(True)
+        _custom_modality_input(mock_gui).setVisible.assert_called_once_with(True)
 
     def test_other_focuses_custom_input(self, mock_gui: MobiMarkerGUI) -> None:
         """Selecting 'Other' focuses custom input field."""
         mock_gui.on_modality_changed("Other")
 
-        mock_gui.custom_modality_input.setFocus.assert_called_once()
+        _custom_modality_input(mock_gui).setFocus.assert_called_once()
 
     def test_standard_modality_hides_input(self, mock_gui: MobiMarkerGUI) -> None:
         """Selecting standard modality hides custom input."""
         mock_gui.on_modality_changed("EEG")
 
-        mock_gui.custom_modality_input.setVisible.assert_called_once_with(False)
+        _custom_modality_input(mock_gui).setVisible.assert_called_once_with(False)
 
 
 class TestOnStreamReady:
@@ -195,19 +235,19 @@ class TestOnStreamReady:
         """Stream ready enables send button."""
         mock_gui.on_stream_ready(True)
 
-        mock_gui.send_button.setEnabled.assert_called_once_with(True)
+        _send_button(mock_gui).setEnabled.assert_called_once_with(True)
 
     def test_ready_enables_modality_button(self, mock_gui: MobiMarkerGUI) -> None:
         """Stream ready enables end modality button."""
         mock_gui.on_stream_ready(True)
 
-        mock_gui.end_modality_button.setEnabled.assert_called_once_with(True)
+        _end_modality_button(mock_gui).setEnabled.assert_called_once_with(True)
 
     def test_ready_enables_quick_buttons(self, mock_gui: MobiMarkerGUI) -> None:
         """Stream ready enables all quick marker buttons."""
         mock_gui.on_stream_ready(True)
 
-        for button in mock_gui.quick_marker_buttons:
+        for button in _quick_marker_buttons(mock_gui):
             button.setEnabled.assert_called_once_with(True)
 
     def test_not_ready_disables_buttons(self, mock_gui: MobiMarkerGUI) -> None:
@@ -215,14 +255,14 @@ class TestOnStreamReady:
         with patch("mobi_marker.gui.format_status_message", return_value="warning"):
             mock_gui.on_stream_ready(False)
 
-        mock_gui.send_button.setEnabled.assert_called_once_with(False)
+        _send_button(mock_gui).setEnabled.assert_called_once_with(False)
 
     def test_not_ready_shows_warning(self, mock_gui: MobiMarkerGUI) -> None:
         """Stream not ready shows warning in status."""
         with patch("mobi_marker.gui.format_status_message", return_value="warning"):
             mock_gui.on_stream_ready(False)
 
-        mock_gui.status_display.append.assert_called()
+        _status_display(mock_gui).append.assert_called()
 
 
 class TestUpdateStatus:
@@ -232,13 +272,13 @@ class TestUpdateStatus:
         """Message is appended to status display."""
         mock_gui.update_status("Test message")
 
-        mock_gui.status_display.append.assert_called_once_with("Test message")
+        _status_display(mock_gui).append.assert_called_once_with("Test message")
 
     def test_scrolls_to_bottom(self, mock_gui: MobiMarkerGUI) -> None:
         """Status display scrolls to bottom."""
         mock_scrollbar = Mock()
         mock_scrollbar.maximum.return_value = 100
-        mock_gui.status_display.verticalScrollBar.return_value = mock_scrollbar
+        _status_display(mock_gui).verticalScrollBar.return_value = mock_scrollbar
 
         mock_gui.update_status("Test")
 
@@ -246,7 +286,7 @@ class TestUpdateStatus:
 
     def test_handles_none_scrollbar(self, mock_gui: MobiMarkerGUI) -> None:
         """Handles None scrollbar gracefully."""
-        mock_gui.status_display.verticalScrollBar.return_value = None
+        _status_display(mock_gui).verticalScrollBar.return_value = None
 
         mock_gui.update_status("Test")  # Should not raise
 
@@ -256,25 +296,25 @@ class TestCloseEvent:
 
     def test_quits_thread(self, mock_gui: MobiMarkerGUI) -> None:
         """Thread is quit on close."""
-        mock_gui.lsl_thread.wait.return_value = True
+        _lsl_thread(mock_gui).wait.return_value = True
         mock_event = Mock()
 
         mock_gui.closeEvent(mock_event)
 
-        mock_gui.lsl_thread.quit.assert_called_once()
+        _lsl_thread(mock_gui).quit.assert_called_once()
 
     def test_waits_for_thread(self, mock_gui: MobiMarkerGUI) -> None:
         """Waits for thread with timeout."""
-        mock_gui.lsl_thread.wait.return_value = True
+        _lsl_thread(mock_gui).wait.return_value = True
         mock_event = Mock()
 
         mock_gui.closeEvent(mock_event)
 
-        mock_gui.lsl_thread.wait.assert_called_once_with(3000)
+        _lsl_thread(mock_gui).wait.assert_called_once_with(3000)
 
     def test_accepts_event(self, mock_gui: MobiMarkerGUI) -> None:
         """Event is accepted."""
-        mock_gui.lsl_thread.wait.return_value = True
+        _lsl_thread(mock_gui).wait.return_value = True
         mock_event = Mock()
 
         mock_gui.closeEvent(mock_event)
@@ -283,13 +323,13 @@ class TestCloseEvent:
 
     def test_timeout_terminates_thread(self, mock_gui: MobiMarkerGUI) -> None:
         """Thread is terminated on timeout."""
-        mock_gui.lsl_thread.wait.side_effect = [False, True]
+        _lsl_thread(mock_gui).wait.side_effect = [False, True]
         mock_event = Mock()
 
         with patch("mobi_marker.gui.format_status_message", return_value="warning"):
             mock_gui.closeEvent(mock_event)
 
-        mock_gui.lsl_thread.terminate.assert_called_once()
+        _lsl_thread(mock_gui).terminate.assert_called_once()
 
     def test_no_thread_still_accepts(self, mock_gui: MobiMarkerGUI) -> None:
         """Event is accepted even with no thread."""
@@ -302,7 +342,7 @@ class TestCloseEvent:
 
     def test_none_event_handled(self, mock_gui: MobiMarkerGUI) -> None:
         """None event is handled gracefully."""
-        mock_gui.lsl_thread.wait.return_value = True
+        _lsl_thread(mock_gui).wait.return_value = True
 
         mock_gui.closeEvent(None)  # Should not raise
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,6 +1,5 @@
 """Tests for the GUI module."""
 
-from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -29,43 +28,43 @@ def mock_gui() -> MobiMarkerGUI:
         return gui
 
 
-def _lsl_thread(gui: MobiMarkerGUI) -> Any:
-    """Return lsl_thread as Any for mock assertions."""
-    return gui.lsl_thread
+def _lsl_thread(gui: MobiMarkerGUI) -> Mock:
+    """Return lsl_thread as Mock for mock assertions."""
+    return gui.lsl_thread  # type: ignore[return-value]
 
 
-def _marker_input(gui: MobiMarkerGUI) -> Any:
-    """Return marker_input as Any for mock assertions."""
-    return gui.marker_input
+def _marker_input(gui: MobiMarkerGUI) -> Mock:
+    """Return marker_input as Mock for mock assertions."""
+    return gui.marker_input  # type: ignore[return-value]
 
 
-def _status_display(gui: MobiMarkerGUI) -> Any:
-    """Return status_display as Any for mock assertions."""
-    return gui.status_display
+def _status_display(gui: MobiMarkerGUI) -> Mock:
+    """Return status_display as Mock for mock assertions."""
+    return gui.status_display  # type: ignore[return-value]
 
 
-def _modality_combo(gui: MobiMarkerGUI) -> Any:
-    """Return modality_combo as Any for mock assertions."""
-    return gui.modality_combo
+def _modality_combo(gui: MobiMarkerGUI) -> Mock:
+    """Return modality_combo as Mock for mock assertions."""
+    return gui.modality_combo  # type: ignore[return-value]
 
 
-def _custom_modality_input(gui: MobiMarkerGUI) -> Any:
-    """Return custom_modality_input as Any for mock assertions."""
-    return gui.custom_modality_input
+def _custom_modality_input(gui: MobiMarkerGUI) -> Mock:
+    """Return custom_modality_input as Mock for mock assertions."""
+    return gui.custom_modality_input  # type: ignore[return-value]
 
 
-def _send_button(gui: MobiMarkerGUI) -> Any:
-    """Return send_button as Any for mock assertions."""
-    return gui.send_button
+def _send_button(gui: MobiMarkerGUI) -> Mock:
+    """Return send_button as Mock for mock assertions."""
+    return gui.send_button  # type: ignore[return-value]
 
 
-def _end_modality_button(gui: MobiMarkerGUI) -> Any:
-    """Return end_modality_button as Any for mock assertions."""
-    return gui.end_modality_button
+def _end_modality_button(gui: MobiMarkerGUI) -> Mock:
+    """Return end_modality_button as Mock for mock assertions."""
+    return gui.end_modality_button  # type: ignore[return-value]
 
 
-def _quick_marker_buttons(gui: MobiMarkerGUI) -> list[Any]:
-    """Return quick_marker_buttons as list[Any] for mock assertions."""
+def _quick_marker_buttons(gui: MobiMarkerGUI) -> list[Mock]:
+    """Return quick_marker_buttons as list[Mock] for mock assertions."""
     return gui.quick_marker_buttons  # type: ignore[return-value]
 
 

--- a/tests/test_lsl_stream.py
+++ b/tests/test_lsl_stream.py
@@ -1,0 +1,289 @@
+"""Tests for the LSL stream module."""
+
+from unittest.mock import Mock, patch
+
+from mobi_marker.lsl_stream import (
+    LSLStreamThread,
+    format_status_message,
+    format_timestamp,
+)
+
+
+class TestFormatTimestamp:
+    """Tests for format_timestamp function."""
+
+    def test_returns_human_time_and_lsl_time(self) -> None:
+        """Returns tuple of human-readable time and LSL clock."""
+        with patch("mobi_marker.lsl_stream.local_clock", return_value=123.456):
+            human_time, lsl_time = format_timestamp()
+
+        assert isinstance(human_time, str)
+        assert lsl_time == 123.456
+
+    def test_human_time_format(self) -> None:
+        """Human time follows expected format."""
+        with patch("mobi_marker.lsl_stream.local_clock", return_value=0):
+            human_time, _ = format_timestamp()
+
+        # Should contain date and time components
+        assert "-" in human_time  # date separator
+        assert ":" in human_time  # time separator
+
+
+class TestFormatStatusMessage:
+    """Tests for format_status_message function."""
+
+    def test_includes_message(self) -> None:
+        """Formatted message includes the input message."""
+        with patch("mobi_marker.lsl_stream.local_clock", return_value=100.0):
+            result = format_status_message("Test message")
+
+        assert "Test message" in result
+
+    def test_includes_timestamps(self) -> None:
+        """Formatted message includes LSL timestamp."""
+        with patch("mobi_marker.lsl_stream.local_clock", return_value=100.0):
+            result = format_status_message("Test")
+
+        assert "100.000" in result
+
+
+class TestLSLStreamThreadInit:
+    """Tests for LSLStreamThread initialization."""
+
+    def test_initializes_with_none_outlet(self) -> None:
+        """Outlet is None before stream starts."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+        ):
+            thread = LSLStreamThread()
+
+        assert thread.outlet is None
+
+    def test_initializes_with_none_stream_info(self) -> None:
+        """Stream info is None before stream starts."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+        ):
+            thread = LSLStreamThread()
+
+        assert thread.stream_info is None
+
+    def test_initializes_not_ready(self) -> None:
+        """Thread is not ready before run() is called."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+        ):
+            thread = LSLStreamThread()
+
+        assert thread._is_ready is False
+
+
+class TestLSLStreamThreadRun:
+    """Tests for LSLStreamThread.run() method."""
+
+    def test_run_success_sets_outlet(self) -> None:
+        """Successful run sets the outlet."""
+        mock_outlet = Mock()
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet", return_value=mock_outlet),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+            patch.object(LSLStreamThread, "exec"),
+        ):
+            thread = LSLStreamThread()
+
+            thread.run()
+
+        assert thread.outlet == mock_outlet
+
+    def test_run_success_sets_ready(self) -> None:
+        """Successful run sets _is_ready to True."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+            patch.object(LSLStreamThread, "exec"),
+        ):
+            thread = LSLStreamThread()
+
+            thread.run()
+
+        assert thread._is_ready is True
+
+    def test_run_success_emits_stream_ready_true(self) -> None:
+        """Successful run emits stream_ready with True."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+            patch.object(LSLStreamThread, "exec"),
+        ):
+            thread = LSLStreamThread()
+            ready_signals: list[bool] = []
+            thread.stream_ready.connect(ready_signals.append)
+
+            thread.run()
+
+        assert ready_signals == [True]
+
+    def test_run_success_emits_status_update(self) -> None:
+        """Successful run emits status update with success message."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+            patch.object(LSLStreamThread, "exec"),
+        ):
+            thread = LSLStreamThread()
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread.run()
+
+        assert len(status_messages) == 1
+        assert "started successfully" in status_messages[0]
+
+    def test_run_failure_emits_stream_ready_false(self) -> None:
+        """Failed run emits stream_ready with False."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo", side_effect=Exception("fail")),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            ready_signals: list[bool] = []
+            thread.stream_ready.connect(ready_signals.append)
+
+            thread.run()
+
+        assert ready_signals == [False]
+
+    def test_run_failure_emits_error_status(self) -> None:
+        """Failed run emits status update with error message."""
+        with (
+            patch(
+                "mobi_marker.lsl_stream.StreamInfo", side_effect=Exception("test error")
+            ),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread.run()
+
+        assert len(status_messages) == 1
+        assert "Error" in status_messages[0]
+        assert "test error" in status_messages[0]
+
+
+class TestLSLStreamThreadSendMarker:
+    """Tests for LSLStreamThread.send_marker() method."""
+
+    def test_send_marker_when_not_ready_emits_error(self) -> None:
+        """Sending marker when not ready emits error status."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread.send_marker("TEST")
+
+        assert len(status_messages) == 1
+        assert "not active" in status_messages[0]
+
+    def test_send_marker_when_ready_emits_request(self) -> None:
+        """Sending marker when ready emits marker_request signal."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+        ):
+            thread = LSLStreamThread()
+            thread._is_ready = True
+            marker_requests: list[str] = []
+            thread.marker_request.connect(marker_requests.append)
+
+            thread.send_marker("TEST_MARKER")
+
+        assert marker_requests == ["TEST_MARKER"]
+
+
+class TestLSLStreamThreadHandleMarkerRequest:
+    """Tests for LSLStreamThread._handle_marker_request() method."""
+
+    def test_handle_request_with_outlet_pushes_sample(self) -> None:
+        """Handler with valid outlet calls push_sample."""
+        mock_outlet = Mock()
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            thread.outlet = mock_outlet
+
+            thread._handle_marker_request("MARKER")
+
+        mock_outlet.push_sample.assert_called_once_with(["MARKER"])
+
+    def test_handle_request_success_emits_status(self) -> None:
+        """Successful marker send emits status update."""
+        mock_outlet = Mock()
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            thread.outlet = mock_outlet
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread._handle_marker_request("MY_MARKER")
+
+        assert len(status_messages) == 1
+        assert "Sent marker: MY_MARKER" in status_messages[0]
+
+    def test_handle_request_with_none_outlet_emits_error(self) -> None:
+        """Handler with None outlet emits error status."""
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            thread.outlet = None
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread._handle_marker_request("MARKER")
+
+        assert len(status_messages) == 1
+        assert "not active" in status_messages[0]
+
+    def test_handle_request_push_failure_emits_error(self) -> None:
+        """Handler emits error when push_sample fails."""
+        mock_outlet = Mock()
+        mock_outlet.push_sample.side_effect = Exception("push failed")
+        with (
+            patch("mobi_marker.lsl_stream.StreamInfo"),
+            patch("mobi_marker.lsl_stream.StreamOutlet"),
+            patch("mobi_marker.lsl_stream.local_clock", return_value=0),
+        ):
+            thread = LSLStreamThread()
+            thread.outlet = mock_outlet
+            status_messages: list[str] = []
+            thread.status_update.connect(status_messages.append)
+
+            thread._handle_marker_request("MARKER")
+
+        assert len(status_messages) == 1
+        assert "Error sending marker" in status_messages[0]
+        assert "push failed" in status_messages[0]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,26 +1,8 @@
-"""Test suite for the MoBI Marker application.
-
-This module contains tests for the main entry points and basic functionality
-of the MoBI Marker application.
-
-Functions:
-    test_import: Tests that the main function can be imported successfully.
-"""
+"""Tests for the main entry point."""
 
 
 def test_import() -> None:
-    """Test that the main function can be imported.
-
-    Verifies that the main function is accessible and callable from
-    the mobi_marker package.
-
-    Returns:
-        None
-
-    Raises:
-        ImportError: If the main function cannot be imported.
-        AssertionError: If the main function is not callable.
-    """
+    """Main function is importable and callable."""
     from mobi_marker import main
 
     assert callable(main)


### PR DESCRIPTION
## Summary
Fix non-systematic crashes by splitting LSL logic into separate module, adding QMutex synchronization, and replacing cross-thread outlet calls with signal-based communication.

## Changes
- Created `lsl_stream.py` with thread-safe `LSLStreamThread`
- Refactored `gui.py` to use signal-based marker sending
- Disabled UI buttons until stream ready to prevent race conditions
- Added graceful shutdown with timeout
- Rewrote tests